### PR TITLE
Поправил регулярное выражение для компонента прикладной архитектуры: …

### DIFF
--- a/_metamodel_/seaf-dzo/entities/app/components/base.yaml
+++ b/_metamodel_/seaf-dzo/entities/app/components/base.yaml
@@ -241,7 +241,7 @@ entities:
               required:
                 - type
       patternProperties:
-        "^[a-zA-Z][a-zA-Z0-9_-]*(\\.[a-zA-Z][a-zA-Z0-9_-]*)*$":
+        "^[a-zA-Z][a-zA-Z0-9_-]*(\\.[a-zA-Z0-9][a-zA-Z0-9_-]*)*$":
           type: object
           properties:
             sber:


### PR DESCRIPTION
…добавил использование цифр в первом символе (т.к. на компонентах 1с, 2gis возникали ошибки)